### PR TITLE
DNA Display Enhancement

### DIFF
--- a/front-end/html/js/moduleChart.js
+++ b/front-end/html/js/moduleChart.js
@@ -1847,19 +1847,19 @@ define([], function () {
                     html_dna_string = [];
                     /* Then for each species sequences, edit the char at each space idx */
                     for (let speciesIdx = 0; speciesIdx < dnaSequences.length; speciesIdx++) {
+                        // TODO: Here is where we can format the chars that are different
+                        if (speciesIdx > 999) dna_string = `${speciesIdx + 1}.`;
+                        else if (speciesIdx > 8) dna_string = `${speciesIdx + 1}..`;
+                        else dna_string = `${speciesIdx + 1}...`;
                         for (let sequenceIdx = 0; sequenceIdx < dnaSequences[speciesIdx].length; sequenceIdx++) {
                             let spaceIdxArr = edit_idxs[sequenceIdx];
-                            content += '<div style="text-align: center; letter-spacing: 1px; font-size: 18px; font-family: Courier New;"><text>';
-                            // TODO: Here is where we can format the chars that are different
-                            if (speciesIdx > 999) dna_string = `${speciesIdx + 1}.`;
-                            else if (speciesIdx > 8) dna_string = `${speciesIdx + 1}..`;
-                            else dna_string = `${speciesIdx + 1}...`;
+                            content += '<div style="text-align: center; letter-spacing: 1px; font-size: 18px; font-family: Courier New,serif;"><text>';
                             for (let charIdx = 0; charIdx < dnaSequences[speciesIdx][sequenceIdx].length; charIdx++) {
                                 if (spaceIdxArr.includes(charIdx)) dna_string += '<text style="color: red"><strong>' + dnaSequences[speciesIdx][sequenceIdx][charIdx] + '</strong></text>';
                                 else dna_string += dnaSequences[speciesIdx][sequenceIdx][charIdx];
                             }
-                            html_dna_string.push(dna_string);
                         }
+                        html_dna_string.push(dna_string);
                     }
                     for (let s = 0; s < 4; s++) {
                         let i = s;


### PR DESCRIPTION
## What
* Increase the size of the nodeInfo display box from 600px to 750px.
* Show the DNA sequences as long strands for each species (rather than broken up into 4 groups.
* Fix the map and photo display at a height of 300px and a width of 432px.
* Dynamically center the photo and map (display: flex; justify-content: center).
* Increase the character spacing for the DNA sequences to 3px.
* Increase the font size of the DNA sequences from 16px to 20px
* Get rid of extra scrollbars showing up in the nodeInfo display.
* Fix spacing between some headers.

## Screenshots
![image](https://user-images.githubusercontent.com/37627395/112728328-4a9a8a00-8eec-11eb-9469-1f326b80315e.png)
![image](https://user-images.githubusercontent.com/37627395/112728335-55edb580-8eec-11eb-8738-ffb34ede55bf.png)
